### PR TITLE
Fix min protocol and add MaxProtocol to config file with proper checking 

### DIFF
--- a/tls_wrapper.c
+++ b/tls_wrapper.c
@@ -281,12 +281,13 @@ tls_opts_t* tls_opts_create(char* path) {
 	ssa_config = get_app_config(path);
 
 	if (ssa_config) {
-		/*if (SSL_CTX_set_min_proto_version(tls_ctx, ssa_config->min_version) == 0) {
+        printf("MinVersion: %d\n", ssa_config->min_version);
+		if (SSL_CTX_set_min_proto_version(tls_ctx, ssa_config->min_version) == 0) {
 			log_printf(LOG_ERROR, "Unable to set min protocol version for %s\n",path);
 		}
 		if (SSL_CTX_set_max_proto_version(tls_ctx, ssa_config->max_version) == 0) {
 			log_printf(LOG_ERROR, "Unable to set max protocol version for %s\n",path);
-		}*/
+		}
 		if (SSL_CTX_set_cipher_list(tls_ctx, ssa_config->cipher_list) == 0) {
 			log_printf(LOG_ERROR, "Unable to set cipher list for %s\n",path);
 		}


### PR DESCRIPTION
Resolves #5 

Makes SSA now parse and use the values MinProtocol and MaxProtocol from the ssa.cfg (before, it parsed but never added them, so the SSA ran on defaults.) It also checks that MinProtocol <= MaxProtocol version to make sure errors don't happen by accident with admins. 

## tls_wrapper.c
Allowed SSA to parse and use values for MinProtocol and MaxProtocol. 

## config.c 
**Lines 210-214** 
I added parsing for the MaxProtocol (because it was missing) to get the values from TLS 1.0 - TLS 1.3. I added a check to set the default value to 1.3 because it seemed more intuitive to set the security to be the best TLS version for the max instead of just exiting if it wasn't found. 

**Lines 241-246**
I also made sure that the MinProtocol version could not be greater than the max protocol version. If this happened, I gave an error and exited because it seemed to be a serious enough issue that the SSA should fail completely to give admins notice of the issue. 

**Lines 256-259**
Did the same Protocol checking with each individual profile. We don't want to profile to accidently set the MaxProtocol version to be lower than the default min protocol version, or visa versa. 
